### PR TITLE
Less repetition in main.py

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -20,6 +20,20 @@ from modules.anim import handleAnim
 # 1 Thread for each file. Controls how many files are worked on at once.
 THREADS = int(os.getenv('fileThreads'))
 
+# [Display name, file extension, handle function]
+MODULES = [
+    ["RPGMaker MV/MZ", "json", handleMVMZ],
+    ["RPGMaker ACE", "yaml", handleACE],
+    ["CSV (From Translator++)", "csv", handleCSV],
+    ["Alice", "txt", handleAlice],
+    ["Tyrano", "ks", handleTyrano],
+    ["JSON", "json", handleJSON],
+    ["Kansen", "ks", handleKansen],
+    ["Lune", "txt", handleLuneTxt],
+    ["Atelier", "txt", handleAtelier],
+    ["Anim", "json", handleAnim],
+]
+
 # Info Message
 tqdm.write(Fore.LIGHTYELLOW_EX + "WARNING: Once a translation starts do not close it unless you want to lose your\
 translated data. If a file fails or gets stuck, translated lines will remain translated so you don't have \
@@ -29,7 +43,7 @@ to worry about being charged twice. You can simply copy the file generated in /t
 def main():
     estimate = ''
     while estimate == '':
-        estimate = input('Select Translation or Cost Estimation:\n\n1. Translate\n2. Estimate\n')
+        estimate = input('Select Translation or Cost Estimation:\n\n 1. Translate\n 2. Estimate\n')
         match estimate:
             case '1':
                 estimate = False
@@ -37,171 +51,41 @@ def main():
                 estimate = True
             case _:
                 estimate = ''
+    
+    version = ''
+    while True:
+        tqdm.write("Select game engine:\n")
+        for position, module in enumerate(MODULES):
+            tqdm.write(f'{str(position + 1).rjust(2)}. {module[0]} (.{module[1]})')
+        version = input()
+        try:
+            version = int(version) - 1
+        except:
+            continue
+        if version in range(len(MODULES)):
+            break    
 
     totalCost = 0
-    version = ''
-    while version == '':
-        version = input('Select the RPGMaker Version:\n\n\
-1. MV/MZ\n\
-2. ACE\n\
-3. CSV (From Translator++)\n\
-4. Alice\n\
-5. Tyrano\n\
-6. JSON\n\
-7. Kansen\n\
-8. Lune\n\
-9. Atelier\n\
-10. Anim\n'
-        )
-        match version:
-            case '1':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleMVMZ, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('json')]
+
+    # Open File (Threads)
+    with ThreadPoolExecutor(max_workers=THREADS) as executor:
+        futures = [executor.submit(MODULES[version][2], filename, estimate) \
+                    for filename in os.listdir("files") if filename.endswith(MODULES[version][1])]
                     
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
+        for future in as_completed(futures):
+            try:
+                totalCost = future.result()
+            except Exception as e:
+                tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
+                tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
 
-            case '2':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleACE, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('yaml')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '3':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleCSV, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('csv')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '4':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleAlice, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('txt')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '5':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleTyrano, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('ks')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '6':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleJSON, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('json')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '7':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleKansen, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('ks')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '8':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleLuneTxt, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('txt')]
-                    
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-                            
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '9':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleAtelier, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('txt')]
-
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case '10':
-                # Open File (Threads)
-                with ThreadPoolExecutor(max_workers=THREADS) as executor:
-                    futures = [executor.submit(handleAnim, filename, estimate) \
-                                for filename in os.listdir("files") if filename.endswith('json')]
-
-                    for future in as_completed(futures):
-                        try:
-                            totalCost = future.result()
-
-                        except Exception as e:
-                            tracebackLineNo = str(traceback.extract_tb(sys.exc_info()[2])[-1].lineno)
-                            tqdm.write(Fore.RED + str(e) + '|' + tracebackLineNo + Fore.RESET)
-
-            case _:
-                version = ''
-        
     if totalCost != 'Fail':
         if estimate is False:
             # This is to encourage people to grab what's in /translated instead
             deleteFolderFiles('files')
 
         # Prevent immediately closing of CLI
-        tqdm.write(totalCost)
+        tqdm.write(str(totalCost))
         # input('Done! Press Enter to close.')
 
 def deleteFolderFiles(folderPath):


### PR DESCRIPTION
Was playing around with adding my own modules and noticed the main.py wasn't very DRY so I decided to refactor it. Modules/versions/game engines are now in their own array along with their file extensions and handling functions at the top. Module list printed to user is automatically generated and the big switch is gone.

Decided to PR this against the rework branch because 1) modules on master are out of date compared to it and 2) this offers no functional benefit to the end user so it doesn't need to hit master any time soon.

I didn't put too much thought into how to design this and just went with what came in my mind, so any edits, suggestions or critiques are very welcome.

/ramble