### PR TITLE
More helpful error messages

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 # upon import, in which case if they are unset the script will crash before we can output these messages.
 envMissing = False
 for env in ['api','key','organization','model','language','timeout','fileThreads','threads','width','listWidth']:
-    if os.getenv(env) is None or str(os.getenv(env))[0] == '<':
+    if os.getenv(env) is None or str(os.getenv(env))[:1] == '<':
         tqdm.write(Fore.RED + f'Environment variable {env} is not set!')
         envMissing = True
 if envMissing:


### PR DESCRIPTION
`main.py` will print more helpful errors if something goes wrong:

- The initial value for `totalCost` is now an error message. As a succesful run of any of the modules should have overwritten it with their results, it remaining unchanged seems a pretty good indicator the script did nothing.
- Check that the environment values are set at the start of `main.py`. If any value returns `None` or a string starting with `<` (as is the case for all the placeholders in `.env.example`) notify the user that they are probably not set. This demystifies the error in https://github.com/dazedanon/DazedMTLTool/issues/10 as `rpgmakermvmz.py` will try to run replace on a potentially unset variable, causing an early crash with an unhelpful error message.